### PR TITLE
Allow to force SMTP client host name

### DIFF
--- a/Mail.ts
+++ b/Mail.ts
@@ -12,6 +12,7 @@ export interface ISmtpConfig {
         secure?: boolean;
         from?: string;
         disabled: boolean;
+        clientHostName?: string;
     },
     mailTo: string;
     replyTo: string;
@@ -68,7 +69,8 @@ export class Mail {
             port: this._config.smtp.port,
             tls: { rejectUnauthorized: false },
             secure: this._config.smtp.secure === true,
-            auth: null
+            auth: null,
+            name: (this._config.smtp.clientHostName && this._config.smtp.clientHostName !== "") ? this._config.smtp.clientHostName : null
         };
 
         if (this._config.smtp.user)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ After installation run `pm2 conf` to configure module. Alternatively edit `modul
         "user": "your-smtp-user",   // auth
         "password": "your-smtp-password",   // auth
         "secure": false,
-        "disabled": false
+        "disabled": false,
+        "clientHostName": "your-machine.com", // optional, will force the client host-name FQDN used in SMTP HELLO. If not set, NodeMailer will ask host name to the OS, and use 127.0.0.1 if it's not a FQDN.
     },
     "mailTo": "mail1,mail2"
 }


### PR DESCRIPTION
Because some OS don't give the FQDN of the machine, and NodeMailer will default to 127.0.0.1 in that case.
SMTP servers may quickly hit their DDOS limits for people sending with "127.0.0.1", leading to missed emails.